### PR TITLE
chore: add code formatter

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,232 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Don't use tabs for indentation.
+[*]
+indent_style = space
+# (Please don't specify an indent_size here; that has too many unintended consequences.)
+
+[Makefile]
+indent_style = tab
+
+# Code files
+[*.{cs,csx,vb,vbx}]
+indent_size = 4
+insert_final_newline = true
+charset = utf-8-bom
+
+# XML project files
+[*.{csproj,vbproj,vcxproj,vcxproj.filters,proj,projitems,shproj}]
+indent_size = 2
+
+# XML config files
+[*.{props,targets,ruleset,config,nuspec,resx,vsixmanifest,vsct}]
+indent_size = 2
+
+# JSON files
+[*.json]
+indent_size = 2
+
+# Powershell files
+[*.ps1]
+indent_size = 2
+
+# Shell script files
+[*.sh]
+end_of_line = lf
+indent_size = 2
+
+# Dotnet code style settings:
+[*.{cs,vb}]
+
+# Sort using and Import directives with System.* appearing first
+dotnet_sort_system_directives_first = true
+dotnet_separate_import_directive_groups = false
+# Avoid "this." and "Me." if not necessary
+dotnet_style_qualification_for_field = false:refactoring
+dotnet_style_qualification_for_property = false:refactoring
+dotnet_style_qualification_for_method = false:refactoring
+dotnet_style_qualification_for_event = false:refactoring
+
+# Use language keywords instead of framework type names for type references
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+dotnet_style_predefined_type_for_member_access = true:suggestion
+
+# Suggest more modern language features when available
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_explicit_tuple_names = true:suggestion
+
+# Whitespace options
+dotnet_style_allow_multiple_blank_lines_experimental = false
+
+# Non-private static fields are PascalCase
+dotnet_naming_rule.non_private_static_fields_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.non_private_static_fields_should_be_pascal_case.symbols = non_private_static_fields
+dotnet_naming_rule.non_private_static_fields_should_be_pascal_case.style = non_private_static_field_style
+
+dotnet_naming_symbols.non_private_static_fields.applicable_kinds = field
+dotnet_naming_symbols.non_private_static_fields.applicable_accessibilities = public, protected, internal, protected_internal, private_protected
+dotnet_naming_symbols.non_private_static_fields.required_modifiers = static
+
+dotnet_naming_style.non_private_static_field_style.capitalization = pascal_case
+
+# Non-private readonly fields are PascalCase
+dotnet_naming_rule.non_private_readonly_fields_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.non_private_readonly_fields_should_be_pascal_case.symbols = non_private_readonly_fields
+dotnet_naming_rule.non_private_readonly_fields_should_be_pascal_case.style = non_private_readonly_field_style
+
+dotnet_naming_symbols.non_private_readonly_fields.applicable_kinds = field
+dotnet_naming_symbols.non_private_readonly_fields.applicable_accessibilities = public, protected, internal, protected_internal, private_protected
+dotnet_naming_symbols.non_private_readonly_fields.required_modifiers = readonly
+
+dotnet_naming_style.non_private_readonly_field_style.capitalization = pascal_case
+
+# Constants are PascalCase
+dotnet_naming_rule.constants_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.constants_should_be_pascal_case.symbols = constants
+dotnet_naming_rule.constants_should_be_pascal_case.style = constant_style
+
+dotnet_naming_symbols.constants.applicable_kinds = field, local
+dotnet_naming_symbols.constants.required_modifiers = const
+
+dotnet_naming_style.constant_style.capitalization = pascal_case
+
+# Static fields are camelCase and start with s_
+dotnet_naming_rule.static_fields_should_be_camel_case.severity = suggestion
+dotnet_naming_rule.static_fields_should_be_camel_case.symbols = static_fields
+dotnet_naming_rule.static_fields_should_be_camel_case.style = static_field_style
+
+dotnet_naming_symbols.static_fields.applicable_kinds = field
+dotnet_naming_symbols.static_fields.required_modifiers = static
+
+dotnet_naming_style.static_field_style.capitalization = camel_case
+dotnet_naming_style.static_field_style.required_prefix = s_
+
+# Instance fields are camelCase and start with _
+dotnet_naming_rule.instance_fields_should_be_camel_case.severity = suggestion
+dotnet_naming_rule.instance_fields_should_be_camel_case.symbols = instance_fields
+dotnet_naming_rule.instance_fields_should_be_camel_case.style = instance_field_style
+
+dotnet_naming_symbols.instance_fields.applicable_kinds = field
+
+dotnet_naming_style.instance_field_style.capitalization = camel_case
+dotnet_naming_style.instance_field_style.required_prefix = _
+
+# Locals and parameters are camelCase
+dotnet_naming_rule.locals_should_be_camel_case.severity = suggestion
+dotnet_naming_rule.locals_should_be_camel_case.symbols = locals_and_parameters
+dotnet_naming_rule.locals_should_be_camel_case.style = camel_case_style
+
+dotnet_naming_symbols.locals_and_parameters.applicable_kinds = parameter, local
+
+dotnet_naming_style.camel_case_style.capitalization = camel_case
+
+# Local functions are PascalCase
+dotnet_naming_rule.local_functions_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.local_functions_should_be_pascal_case.symbols = local_functions
+dotnet_naming_rule.local_functions_should_be_pascal_case.style = local_function_style
+
+dotnet_naming_symbols.local_functions.applicable_kinds = local_function
+
+dotnet_naming_style.local_function_style.capitalization = pascal_case
+
+# By default, name items with PascalCase
+dotnet_naming_rule.members_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.members_should_be_pascal_case.symbols = all_members
+dotnet_naming_rule.members_should_be_pascal_case.style = pascal_case_style
+
+dotnet_naming_symbols.all_members.applicable_kinds = *
+
+dotnet_naming_style.pascal_case_style.capitalization = pascal_case
+
+file_header_template = Licensed to the .NET Foundation under one or more agreements.\nThe .NET Foundation licenses this file to you under the MIT license.\nSee the LICENSE file in the project root for more information.
+
+# RS0016: Only enable if API files are present
+dotnet_public_api_analyzer.require_api_files = true
+
+# CSharp code style settings:
+[*.cs]
+# Newline settings
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true
+
+# Indentation preferences
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents = true
+csharp_indent_case_contents_when_block = true
+csharp_indent_switch_labels = true
+csharp_indent_labels = flush_left
+
+# Whitespace options
+csharp_style_allow_embedded_statements_on_same_line_experimental = false
+csharp_style_allow_blank_lines_between_consecutive_braces_experimental = false
+csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = false
+csharp_style_allow_blank_line_after_token_in_conditional_expression_experimental = false
+csharp_style_allow_blank_line_after_token_in_arrow_expression_clause_experimental = false
+
+# Prefer "var" everywhere
+csharp_style_var_for_built_in_types = true:suggestion
+csharp_style_var_when_type_is_apparent = true:suggestion
+csharp_style_var_elsewhere = true:suggestion
+
+# Prefer method-like constructs to have a block body
+csharp_style_expression_bodied_methods = false:none
+csharp_style_expression_bodied_constructors = false:none
+csharp_style_expression_bodied_operators = false:none
+
+# Prefer property-like constructs to have an expression-body
+csharp_style_expression_bodied_properties = true:none
+csharp_style_expression_bodied_indexers = true:none
+csharp_style_expression_bodied_accessors = true:none
+
+# Suggest more modern language features when available
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+csharp_style_throw_expression = true:suggestion
+csharp_style_conditional_delegate_call = true:suggestion
+csharp_style_prefer_extended_property_pattern = true:suggestion
+
+# Space preferences
+csharp_space_after_cast = false
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_after_comma = true
+csharp_space_after_dot = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_after_semicolon_in_for_statement = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_around_declaration_statements = do_not_ignore
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_before_comma = false
+csharp_space_before_dot = false
+csharp_space_before_open_square_brackets = false
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_between_square_brackets = false
+
+# Blocks are allowed
+csharp_prefer_braces = true:silent
+csharp_preserve_single_line_blocks = true
+csharp_preserve_single_line_statements = true
+
+# IDE0060: Remove unused parameter
+# This is less useful since we are wrapping an API and discarding parameters
+#dotnet_diagnostic.IDE0060.severity = warning

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Build
         run: dotnet build
 
+      - name: Format
+        run: dotnet format --verify-no-changes
+
       - name: Test
         run: dotnet test -f net6.0
 
@@ -60,6 +63,9 @@ jobs:
 
       - name: Build
         run: dotnet build
+
+      - name: Format
+        run: dotnet format --verify-no-changes
 
       - name: Test
         run: dotnet test -f net461

--- a/Makefile
+++ b/Makefile
@@ -20,9 +20,10 @@ clean:
 clean-build: clean restore build
 
 
-.PHONY: precommit
-## Run clean-build and test as a step before committing.
-precommit: clean-build test
+.PHONY: format
+## Format code
+format:
+	@dotnet format
 
 
 .PHONY: restore
@@ -35,6 +36,22 @@ restore:
 ## Run unit and integration tests
 test:
 	@dotnet test
+
+
+.PHONY: test-net6
+## Run unit and integration tests against .NET 6
+test-net6:
+	@dotnet test --framework net6.0
+
+
+.PHONY: precommit
+## Run clean-build, format, and test as a step before committing.
+precommit: clean-build format test
+
+
+.PHONY: precommit-net6
+## Run clean-build, format, and test as a step before committing.
+precommit-net6: clean-build format test-net6
 
 
 # See <https://gist.github.com/klmr/575726c7e05d8780505a> for explanation.

--- a/src/Momento.StackExchange.Redis/MomentoRedisDatabase.Geo.cs
+++ b/src/Momento.StackExchange.Redis/MomentoRedisDatabase.Geo.cs
@@ -1,4 +1,4 @@
-using StackExchange.Redis;
+﻿using StackExchange.Redis;
 
 namespace Momento.StackExchange.Redis;
 

--- a/src/Momento.StackExchange.Redis/MomentoRedisDatabase.Hash.cs
+++ b/src/Momento.StackExchange.Redis/MomentoRedisDatabase.Hash.cs
@@ -1,4 +1,4 @@
-using StackExchange.Redis;
+﻿using StackExchange.Redis;
 
 namespace Momento.StackExchange.Redis;
 

--- a/src/Momento.StackExchange.Redis/MomentoRedisDatabase.HyperLogLog.cs
+++ b/src/Momento.StackExchange.Redis/MomentoRedisDatabase.HyperLogLog.cs
@@ -1,4 +1,4 @@
-using StackExchange.Redis;
+﻿using StackExchange.Redis;
 
 namespace Momento.StackExchange.Redis;
 

--- a/src/Momento.StackExchange.Redis/MomentoRedisDatabase.Key.cs
+++ b/src/Momento.StackExchange.Redis/MomentoRedisDatabase.Key.cs
@@ -1,4 +1,4 @@
-using System.Net;
+﻿using System.Net;
 using StackExchange.Redis;
 
 namespace Momento.StackExchange.Redis;

--- a/src/Momento.StackExchange.Redis/MomentoRedisDatabase.List.cs
+++ b/src/Momento.StackExchange.Redis/MomentoRedisDatabase.List.cs
@@ -1,4 +1,4 @@
-using StackExchange.Redis;
+﻿using StackExchange.Redis;
 
 namespace Momento.StackExchange.Redis;
 

--- a/src/Momento.StackExchange.Redis/MomentoRedisDatabase.Lock.cs
+++ b/src/Momento.StackExchange.Redis/MomentoRedisDatabase.Lock.cs
@@ -1,4 +1,4 @@
-using StackExchange.Redis;
+﻿using StackExchange.Redis;
 
 namespace Momento.StackExchange.Redis;
 

--- a/src/Momento.StackExchange.Redis/MomentoRedisDatabase.Set.cs
+++ b/src/Momento.StackExchange.Redis/MomentoRedisDatabase.Set.cs
@@ -1,4 +1,4 @@
-using StackExchange.Redis;
+﻿using StackExchange.Redis;
 
 namespace Momento.StackExchange.Redis;
 

--- a/src/Momento.StackExchange.Redis/MomentoRedisDatabase.Sort.cs
+++ b/src/Momento.StackExchange.Redis/MomentoRedisDatabase.Sort.cs
@@ -1,4 +1,4 @@
-using StackExchange.Redis;
+﻿using StackExchange.Redis;
 
 namespace Momento.StackExchange.Redis;
 

--- a/src/Momento.StackExchange.Redis/MomentoRedisDatabase.SortedSet.cs
+++ b/src/Momento.StackExchange.Redis/MomentoRedisDatabase.SortedSet.cs
@@ -1,4 +1,4 @@
-using StackExchange.Redis;
+﻿using StackExchange.Redis;
 
 namespace Momento.StackExchange.Redis;
 

--- a/src/Momento.StackExchange.Redis/MomentoRedisDatabase.Stream.cs
+++ b/src/Momento.StackExchange.Redis/MomentoRedisDatabase.Stream.cs
@@ -1,4 +1,4 @@
-using StackExchange.Redis;
+﻿using StackExchange.Redis;
 
 namespace Momento.StackExchange.Redis;
 

--- a/src/Momento.StackExchange.Redis/MomentoRedisDatabase.String.cs
+++ b/src/Momento.StackExchange.Redis/MomentoRedisDatabase.String.cs
@@ -1,4 +1,4 @@
-using Momento.Sdk.Responses;
+﻿using Momento.Sdk.Responses;
 using StackExchange.Redis;
 
 namespace Momento.StackExchange.Redis;

--- a/src/Momento.StackExchange.Redis/MomentoRedisDatabase.cs
+++ b/src/Momento.StackExchange.Redis/MomentoRedisDatabase.cs
@@ -1,4 +1,4 @@
-using System.Net;
+﻿using System.Net;
 using Momento.Sdk;
 using StackExchange.Redis;
 

--- a/src/Momento.StackExchange.Redis/TypeForwarders.cs
+++ b/src/Momento.StackExchange.Redis/TypeForwarders.cs
@@ -1,4 +1,4 @@
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 using StackExchange.Redis;
 
 /*

--- a/tests/Integration/Momento.StackExchange.Redis.Tests/Fixtures.cs
+++ b/tests/Integration/Momento.StackExchange.Redis.Tests/Fixtures.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using Momento.Sdk;
 using Momento.Sdk.Auth;
 using Momento.Sdk.Config;

--- a/tests/Integration/Momento.StackExchange.Redis.Tests/StringTest.cs
+++ b/tests/Integration/Momento.StackExchange.Redis.Tests/StringTest.cs
@@ -1,4 +1,4 @@
-using StackExchange.Redis;
+﻿using StackExchange.Redis;
 
 namespace Momento.StackExchange.Redis.Tests;
 

--- a/tests/Integration/Momento.StackExchange.Redis.Tests/TestBase.cs
+++ b/tests/Integration/Momento.StackExchange.Redis.Tests/TestBase.cs
@@ -1,4 +1,4 @@
-using StackExchange.Redis;
+﻿using StackExchange.Redis;
 
 
 namespace Momento.StackExchange.Redis.Tests;

--- a/tests/Integration/Momento.StackExchange.Redis.Tests/Usings.cs
+++ b/tests/Integration/Momento.StackExchange.Redis.Tests/Usings.cs
@@ -1,1 +1,1 @@
-global using Xunit;
+﻿global using Xunit;

--- a/tests/Integration/Momento.StackExchange.Redis.Tests/Utils.cs
+++ b/tests/Integration/Momento.StackExchange.Redis.Tests/Utils.cs
@@ -1,4 +1,4 @@
-namespace Momento.StackExchange.Redis.Tests;
+﻿namespace Momento.StackExchange.Redis.Tests;
 
 public class Utils
 {


### PR DESCRIPTION
Adds a .editorconfig with code formatting rules from the Roslyn
project (C# compiler), adds a format makefile target, and updates CI
to test no formatting changes needed.

closes: #16 