### PR TITLE
refactor: use Momento `IError` interface for error conversion

### DIFF
--- a/src/Momento.StackExchange.Redis/Momento.StackExchange.Redis.csproj
+++ b/src/Momento.StackExchange.Redis/Momento.StackExchange.Redis.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Momento.Sdk" Version="1.11.0" />
+    <PackageReference Include="Momento.Sdk" Version="1.11.1" />
     <PackageReference Include="StackExchange.Redis" Version="2.6.104" />
 
     <!-- Propagated from StackExchange.Redis; built into .NET core now.

--- a/src/Momento.StackExchange.Redis/MomentoRedisDatabase.Key.cs
+++ b/src/Momento.StackExchange.Redis/MomentoRedisDatabase.Key.cs
@@ -37,7 +37,7 @@ public sealed partial class MomentoRedisDatabase : IDatabase
         }
         else if (response is CacheDeleteResponse.Error error)
         {
-            throw ConvertMomentoErrorToRedisException(error.Message, error.InnerException, error.ErrorCode);
+            throw ConvertMomentoErrorToRedisException(error);
         }
         else
         {

--- a/src/Momento.StackExchange.Redis/MomentoRedisDatabase.String.cs
+++ b/src/Momento.StackExchange.Redis/MomentoRedisDatabase.String.cs
@@ -118,7 +118,7 @@ public sealed partial class MomentoRedisDatabase : IDatabase
         }
         else if (response is CacheGetResponse.Error error)
         {
-            throw ConvertMomentoErrorToRedisException(error.Message, error.InnerException, error.ErrorCode);
+            throw ConvertMomentoErrorToRedisException(error);
         }
         else
         {
@@ -325,7 +325,7 @@ public sealed partial class MomentoRedisDatabase : IDatabase
         }
         else if (response is CacheSetResponse.Error error)
         {
-            throw ConvertMomentoErrorToRedisException(error.Message, error.InnerException, error.ErrorCode);
+            throw ConvertMomentoErrorToRedisException(error);
         }
         else
         {


### PR DESCRIPTION
In the previous version of `Momento.Sdk`, there was no common error
base type. In version 1.11.1 we introduced a common interface. With
that we refactor the compatiblity client error conversion to take
advantage of that.
