### PR TITLE
chore: validate unsupported arguments

### DIFF
--- a/src/Momento.StackExchange.Redis/IMomentoRedisDatabase.cs
+++ b/src/Momento.StackExchange.Redis/IMomentoRedisDatabase.cs
@@ -1,5 +1,4 @@
-﻿using System.Net;
-using StackExchange.Redis;
+﻿using StackExchange.Redis;
 namespace Momento.StackExchange.Redis;
 
 public interface IMomentoRedisDatabase

--- a/src/Momento.StackExchange.Redis/MomentoRedisDatabase.Key.cs
+++ b/src/Momento.StackExchange.Redis/MomentoRedisDatabase.Key.cs
@@ -28,6 +28,8 @@ public sealed partial class MomentoRedisDatabase : IDatabase
 
     public async Task<bool> KeyDeleteAsync(RedisKey key, CommandFlags flags = CommandFlags.None)
     {
+        WarnOnFireAndForget(flags);
+
         var response = await Client.DeleteAsync(CacheName, (string)key!);
         if (response is CacheDeleteResponse.Success)
         {

--- a/src/Momento.StackExchange.Redis/MomentoRedisDatabase.String.cs
+++ b/src/Momento.StackExchange.Redis/MomentoRedisDatabase.String.cs
@@ -107,6 +107,8 @@ public sealed partial class MomentoRedisDatabase : IDatabase
 
     public async Task<RedisValue> StringGetAsync(RedisKey key, CommandFlags flags = CommandFlags.None)
     {
+        WarnOnFireAndForget(flags);
+
         var response = await Client.GetAsync(CacheName, key.ToString());
         if (response is CacheGetResponse.Hit hit)
         {
@@ -313,10 +315,7 @@ public sealed partial class MomentoRedisDatabase : IDatabase
 
     public async Task<bool> StringSetAsync(RedisKey key, RedisValue value, TimeSpan? expiry, When when)
     {
-        if (when != When.Always)
-        {
-            throw new NotImplementedException();
-        }
+        AssertStringWhenImplemented(when, "StringSetAsync");
 
         var response = await Client.SetAsync(CacheName, (string)key!, (string)value!, expiry);
         if (response is CacheSetResponse.Success)

--- a/tests/Integration/Momento.StackExchange.Redis.Tests/StringTest.cs
+++ b/tests/Integration/Momento.StackExchange.Redis.Tests/StringTest.cs
@@ -10,7 +10,7 @@ public class StringTest : TestBase
     }
 
     [Fact]
-    public void Get_MissingCache_ThrowsException()
+    public void StringGet_MissingCache_ThrowsException()
     {
         if (useRedis)
         {
@@ -22,7 +22,7 @@ public class StringTest : TestBase
     }
 
     [Fact]
-    public async Task GetAsync_MissingCache_ThrowsException()
+    public async Task StringGetAsync_MissingCache_ThrowsException()
     {
         if (useRedis)
         {
@@ -34,21 +34,21 @@ public class StringTest : TestBase
     }
 
     [Fact]
-    public void Get_MissingKey_HappyPath()
+    public void StringGet_MissingKey_HappyPath()
     {
         var result = db.StringGet(Utils.GuidString());
         Assert.True(result.IsNull);
     }
 
     [Fact]
-    public async Task GetAsync_MissingKey_HappyPath()
+    public async Task StringGetAsync_MissingKey_HappyPath()
     {
         var result = await db.StringGetAsync(Utils.GuidString());
         Assert.True(result.IsNull);
     }
 
     [Fact]
-    public void Set_NoExpiry_HappyPath()
+    public void StringSet_NoExpiry_HappyPath()
     {
         var key = Utils.GuidString();
         var value = Utils.GuidString();
@@ -60,7 +60,7 @@ public class StringTest : TestBase
     }
 
     [Fact]
-    public async Task SetAsync_NoExpiry_HappyPath()
+    public async Task StringSetAsync_NoExpiry_HappyPath()
     {
         var key = Utils.GuidString();
         var value = Utils.GuidString();
@@ -72,7 +72,38 @@ public class StringTest : TestBase
     }
 
     [Fact]
-    public void SetAsync_HasExpiryAndExpires_HappyPath()
+    public void StringSet_WhenExists_ThrowsException()
+    {
+        if (useRedis)
+        {
+            return;
+        }
+
+        var key = Utils.GuidString();
+        var value = Utils.GuidString();
+        var exception = Record.Exception(() => db.StringSet(key, value, null, When.Exists));
+        Assert.IsType<NotImplementedException>(exception);
+        // Note that because we delegate synchronous calls to asynchronous calls, the exception message will be that of the asynchronous call.
+        Assert.StartsWith("Command StringSetAsync with When.Exists is not yet supported in MomentoRedisClient", exception.Message);
+    }
+
+    [Fact]
+    public async Task StringSetAsync_WhenExists_ThrowsException()
+    {
+        if (useRedis)
+        {
+            return;
+        }
+
+        var key = Utils.GuidString();
+        var value = Utils.GuidString();
+        var exception = await Record.ExceptionAsync(() => db.StringSetAsync(key, value, null, When.Exists));
+        Assert.IsType<NotImplementedException>(exception);
+        Assert.StartsWith("Command StringSetAsync with When.Exists is not yet supported in MomentoRedisClient", exception.Message);
+    }
+
+    [Fact]
+    public void StringSet_HasExpiryAndExpires_HappyPath()
     {
         var key = Utils.GuidString();
         var value = Utils.GuidString();
@@ -89,7 +120,7 @@ public class StringTest : TestBase
     }
 
     [Fact]
-    public async Task SetAsync_HasExpiryAndExpires_HappyPathAsync()
+    public async Task StringSetAsync_HasExpiryAndExpires_HappyPath()
     {
         var key = Utils.GuidString();
         var value = Utils.GuidString();


### PR DESCRIPTION
Log a warning on `CommandFlags.FireAndForget`* and throw an exception
on unsupported arguments such as `When.Exists`.

*All of the `CommandFlag` options are irrelevant for our use
cases. They are options for when in Redis cluster mode.

closes #31
